### PR TITLE
Block dodgy user-agents

### DIFF
--- a/internal/service/web.go
+++ b/internal/service/web.go
@@ -173,6 +173,8 @@ func blockAgents(next http.Handler) http.Handler {
 				return
 			}
 		}
+		// temp
+		slog.Info(fmt.Sprintf("allowed user agent: %s", r.UserAgent()))
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
One user-agent is making up ~98% of requests. blocking it for now, i don't care if it's legit.

<img width="1388" alt="Screenshot 2024-02-11 at 11 18 30 pm" src="https://github.com/devhou-se/sreetcode/assets/5674656/67fb9734-7d8e-4968-89d8-4c3782919975">
ignore "grpc-go", that's just the internal calls to sreeifier
